### PR TITLE
Remove trailing dot from description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kap-recording-time",
   "version": "1.0.2",
-  "description": "Show time elapsed while recording.",
+  "description": "Show time elapsed while recording",
   "repository": "https://github.com/karaggeorge/kap-recording-time",
   "author": {
     "name": "George Karagkiaouris",


### PR DESCRIPTION
The same applies to your `kap-camera` plugin.